### PR TITLE
build.sh: Add Logging functionality to kernel build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,9 @@
 
 KERNEL_NAME="Enigma"
 DATE=$(date +"%d-%m-%Y-%I-%M")
+SHORTDATE=$(date +"%d-%m-%Y")
+LOG_DIR=~/logs
+LOG="Build"-$SHORTDATE
 FINAL_ZIP=$KERNEL_NAME-$DATE.zip
 
 if [ "$(cat /sys/devices/system/cpu/smt/active)" = "1" ]; then
@@ -85,11 +88,11 @@ echo -n "Choose :"
 read choose
 
 case $choose in
- 1) dirty_compile
-    make_zip ;;
- 2) clean_compile
-    make_zip ;;
- 3) regen ;;
+ 1) dirty_compile | tee -a "$LOG_DIR"/"$LOG"
+    make_zip | tee -a "$LOG_DIR"/"$LOG" ;;
+ 2) clean_compile | tee -a "$LOG_DIR"/"$LOG" 
+    make_zip | tee -a "$LOG_DIR"/"$LOG" ;;
+ 3) regen | tee -a "$LOG_DIR"/"$LOG" ;;
 esac
 }
 

--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,7 @@ echo "---------------------------------------"
 # Clean Up
 function cleanup(){
 rm -rf /home/thanuj/sdm660/AnyKernel3/Image.gz-dtb
+sed -i 's/\x1b\[[0-9;]*[a-zA-Z]//g' "$LOG_DIR"/"$LOG"
 }
 
 # Menu


### PR DESCRIPTION
Pretty self explanatory. Make sure LOG_DIR is set to a directory that exists. Otherwise, it may break script